### PR TITLE
Add Rust socket client and Docker integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "socket_client"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,13 @@ RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --upgrade -r /usr/llm/requirements.txt
 
 CMD [ "python", "app.py" ]
+
+# Build stage for Rust client
+FROM rust:latest AS rust-client
+
+WORKDIR /usr/src/rust
+
+# Build the Rust client
+RUN cargo build --release
+
+CMD [ "cargo", "run" ]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,18 @@
 This project is  simple POC to have a locally installed LLM that listens and responds to prompts over a socket server.
 
 Eventually, I'd like to use this server as a service for more complicated web apps to use an LLM that exists side by side on the same machine, without needing to connect to a third party API.
+
+## Rust Socket Client
+
+This project also includes a Rust socket client that sends a message to port 65432 and listens for a response.
+
+### Building the Rust Socket Client
+
+1. Ensure you have Rust installed. If not, you can install it from [rust-lang.org](https://www.rust-lang.org/).
+2. Navigate to the `rust` directory.
+3. Run `cargo build` to build the project.
+
+### Running the Rust Socket Client
+
+1. After building the project, run `cargo run` to start the Rust socket client.
+2. The client will send a message to port 65432 and print the response from the server.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,10 @@ services:
     environment:
       HF_HOME: /usr/llm/.cache
     env_file: .env
+
+  client:
+    build:
+      context: .
+      target: rust-client
+    volumes:
+      - ./rust:/usr/src/rust

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "socket_client"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,31 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+fn main() {
+    // Connect to the server at port 65432
+    match TcpStream::connect("127.0.0.1:65432") {
+        Ok(mut stream) => {
+            println!("Successfully connected to server at port 65432");
+
+            // Send a message to the server
+            let msg = b"What is the capital of the USA?";
+            stream.write(msg).unwrap();
+            println!("Sent message: {}", String::from_utf8_lossy(msg));
+
+            // Read the response from the server
+            let mut buffer = [0; 1024];
+            match stream.read(&mut buffer) {
+                Ok(_) => {
+                    let response = String::from_utf8_lossy(&buffer);
+                    println!("Received response: {}", response);
+                }
+                Err(e) => {
+                    println!("Failed to receive data: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            println!("Failed to connect: {}", e);
+        }
+    }
+}


### PR DESCRIPTION
Test out copilot workspace to create a socket client in Rust that will handle prompting the local LLM.

This client will serve as a POC for other clients

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/stbarrientos/socket-llm?shareId=1ae16303-a2c9-49c5-b3b3-ba278088c696).